### PR TITLE
Add a rainbow coloured 3D sphere

### DIFF
--- a/MonoGameTest/Content/Content.mgcb
+++ b/MonoGameTest/Content/Content.mgcb
@@ -1,4 +1,3 @@
-
 #----------------------------- Global Properties ----------------------------#
 
 /outputDir:bin/$(Platform)
@@ -13,3 +12,14 @@
 
 #---------------------------------- Content ---------------------------------#
 
+# Begin 3D sphere model
+# Model: Sphere
+# Path: Models/Sphere.fbx
+/processor:ModelProcessor
+/build:Models/Sphere.fbx
+
+# Begin rainbow texture
+# Texture: Rainbow
+# Path: Textures/Rainbow.png
+/processor:TextureProcessor
+/build:Textures/Rainbow.png

--- a/MonoGameTest/Game1.cs
+++ b/MonoGameTest/Game1.cs
@@ -9,6 +9,10 @@ namespace MonoGameTest
         private GraphicsDeviceManager _graphics;
         private SpriteBatch _spriteBatch;
 
+        private Model _sphereModel;
+        private Texture2D _rainbowTexture;
+        private BasicEffect _effect;
+
         public Game1()
         {
             _graphics = new GraphicsDeviceManager(this);
@@ -27,7 +31,16 @@ namespace MonoGameTest
         {
             _spriteBatch = new SpriteBatch(GraphicsDevice);
 
-            // TODO: use this.Content to load your game content here
+            _sphereModel = Content.Load<Model>("Models/Sphere");
+            _rainbowTexture = Content.Load<Texture2D>("Textures/Rainbow");
+
+            _effect = new BasicEffect(GraphicsDevice)
+            {
+                TextureEnabled = true,
+                Texture = _rainbowTexture,
+                LightingEnabled = false,
+                VertexColorEnabled = false
+            };
         }
 
         protected override void Update(GameTime gameTime)
@@ -44,7 +57,18 @@ namespace MonoGameTest
         {
             GraphicsDevice.Clear(Color.Black);
 
-            // TODO: Add your drawing code here
+            foreach (var mesh in _sphereModel.Meshes)
+            {
+                foreach (BasicEffect effect in mesh.Effects)
+                {
+                    effect.World = Matrix.CreateTranslation(Vector3.Zero);
+                    effect.View = Matrix.CreateLookAt(new Vector3(0, 0, 5), Vector3.Zero, Vector3.Up);
+                    effect.Projection = Matrix.CreatePerspectiveFieldOfView(MathHelper.PiOver4, GraphicsDevice.Viewport.AspectRatio, 0.1f, 100f);
+                    effect.Texture = _rainbowTexture;
+                    effect.TextureEnabled = true;
+                }
+                mesh.Draw();
+            }
 
             base.Draw(gameTime);
         }


### PR DESCRIPTION
Fixes #1

Add a rainbow coloured 3D sphere to the game.

* **Content Pipeline**: Add a 3D sphere model and a rainbow texture to the `MonoGameTest/Content/Content.mgcb` file.
* **Game Initialization**: Add fields for the 3D sphere model, texture, and basic effect in `MonoGameTest/Game1.cs`.
* **Load Content**: Load the 3D sphere model and rainbow texture in the `LoadContent` method.
* **Render Sphere**: Render the 3D sphere with the rainbow texture in the `Draw` method.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/JoshGibsonUOH/WorkspaceMonoGame/issues/1?shareId=ed46d499-0abd-4a35-8a22-2d0204052f1c).