### PR TITLE
Add programmatic sphere model and rainbow texture

### DIFF
--- a/MonoGameTest/Content/Content.mgcb
+++ b/MonoGameTest/Content/Content.mgcb
@@ -12,14 +12,3 @@
 
 #---------------------------------- Content ---------------------------------#
 
-# Begin 3D sphere model
-# Model: Sphere
-# Path: Models/Sphere.fbx
-/processor:ModelProcessor
-/build:Models/Sphere.fbx
-
-# Begin rainbow texture
-# Texture: Rainbow
-# Path: Textures/Rainbow.png
-/processor:TextureProcessor
-/build:Textures/Rainbow.png

--- a/MonoGameTest/Game1.cs
+++ b/MonoGameTest/Game1.cs
@@ -1,6 +1,7 @@
 ﻿using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
 using Microsoft.Xna.Framework.Input;
+using System;
 
 namespace MonoGameTest
 {
@@ -31,8 +32,8 @@ namespace MonoGameTest
         {
             _spriteBatch = new SpriteBatch(GraphicsDevice);
 
-            _sphereModel = Content.Load<Model>("Models/Sphere");
-            _rainbowTexture = Content.Load<Texture2D>("Textures/Rainbow");
+            _sphereModel = CreateSphereModel();
+            _rainbowTexture = CreateRainbowTexture();
 
             _effect = new BasicEffect(GraphicsDevice)
             {
@@ -41,6 +42,102 @@ namespace MonoGameTest
                 LightingEnabled = false,
                 VertexColorEnabled = false
             };
+        }
+
+        private Model CreateSphereModel()
+        {
+            // Create a sphere model programmatically
+            int tessellation = 16;
+            VertexPositionNormalTexture[] vertices = new VertexPositionNormalTexture[(tessellation + 1) * (tessellation + 1)];
+            int[] indices = new int[tessellation * tessellation * 6];
+
+            int vertexCount = 0;
+            int indexCount = 0;
+
+            for (int i = 0; i <= tessellation; i++)
+            {
+                float latitude = (float)i * MathHelper.Pi / tessellation;
+                float dy = (float)Math.Cos(latitude);
+                float dxz = (float)Math.Sin(latitude);
+
+                for (int j = 0; j <= tessellation; j++)
+                {
+                    float longitude = (float)j * MathHelper.TwoPi / tessellation;
+                    float dx = (float)Math.Sin(longitude);
+                    float dz = (float)Math.Cos(longitude);
+
+                    Vector3 normal = new Vector3(dx * dxz, dy, dz * dxz);
+                    Vector2 textureCoordinate = new Vector2((float)j / tessellation, (float)i / tessellation);
+
+                    vertices[vertexCount++] = new VertexPositionNormalTexture(normal, normal, textureCoordinate);
+
+                    if (i < tessellation && j < tessellation)
+                    {
+                        indices[indexCount++] = i * (tessellation + 1) + j;
+                        indices[indexCount++] = (i + 1) * (tessellation + 1) + j;
+                        indices[indexCount++] = i * (tessellation + 1) + j + 1;
+
+                        indices[indexCount++] = i * (tessellation + 1) + j + 1;
+                        indices[indexCount++] = (i + 1) * (tessellation + 1) + j;
+                        indices[indexCount++] = (i + 1) * (tessellation + 1) + j + 1;
+                    }
+                }
+            }
+
+            VertexBuffer vertexBuffer = new VertexBuffer(GraphicsDevice, typeof(VertexPositionNormalTexture), vertices.Length, BufferUsage.WriteOnly);
+            vertexBuffer.SetData(vertices);
+
+            IndexBuffer indexBuffer = new IndexBuffer(GraphicsDevice, IndexElementSize.ThirtyTwoBits, indices.Length, BufferUsage.WriteOnly);
+            indexBuffer.SetData(indices);
+
+            ModelMeshPart meshPart = new ModelMeshPart
+            {
+                VertexBuffer = vertexBuffer,
+                IndexBuffer = indexBuffer,
+                NumVertices = vertices.Length,
+                PrimitiveCount = indices.Length / 3,
+                StartIndex = 0,
+                VertexOffset = 0
+            };
+
+            ModelMesh mesh = new ModelMesh(GraphicsDevice, new[] { meshPart });
+            Model model = new Model(GraphicsDevice, new[] { mesh });
+
+            return model;
+        }
+
+        private Texture2D CreateRainbowTexture()
+        {
+            // Create a rainbow texture programmatically
+            int width = 256;
+            int height = 256;
+            Texture2D texture = new Texture2D(GraphicsDevice, width, height);
+
+            Color[] colors = new Color[width * height];
+            for (int y = 0; y < height; y++)
+            {
+                for (int x = 0; x < width; x++)
+                {
+                    float hue = (float)x / width;
+                    colors[y * width + x] = ColorFromHue(hue);
+                }
+            }
+
+            texture.SetData(colors);
+            return texture;
+        }
+
+        private Color ColorFromHue(float hue)
+        {
+            float r = Math.Abs(hue * 6 - 3) - 1;
+            float g = 2 - Math.Abs(hue * 6 - 2);
+            float b = 2 - Math.Abs(hue * 6 - 4);
+            return new Color(Clamp(r), Clamp(g), Clamp(b));
+        }
+
+        private float Clamp(float value)
+        {
+            return Math.Max(0, Math.Min(1, value));
         }
 
         protected override void Update(GameTime gameTime)


### PR DESCRIPTION
Fixes #3

Create the Sphere Model and Rainbow Texture programmatically.

* Add `CreateSphereModel` method to generate a sphere model programmatically in `MonoGameTest/Game1.cs`.
* Add `CreateRainbowTexture` method to generate a rainbow texture programmatically in `MonoGameTest/Game1.cs`.
* Update `LoadContent` method in `MonoGameTest/Game1.cs` to use the programmatically generated sphere model and rainbow texture.
* Remove references to the Sphere Model and Rainbow Texture files in `MonoGameTest/Content/Content.mgcb`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/JoshGibsonUOH/WorkspaceMonoGame/issues/3?shareId=dad38aa2-4cdf-4dc6-b7b6-36dfc2e80e55).